### PR TITLE
Refactor Kanban column header styles

### DIFF
--- a/src/modules/kanban.js
+++ b/src/modules/kanban.js
@@ -726,30 +726,21 @@ window.CRMKanban = (() => {
     // Header da coluna
     const header = document.createElement('div');
     header.className = 'column-header';
-    header.style.marginBottom = '16px';
 
     // Container flexível para título + botões no topo
     const headerTop = document.createElement('div');
-    headerTop.style.display = 'flex';
-    headerTop.style.justifyContent = 'space-between';
-    headerTop.style.alignItems = 'center';
-    headerTop.style.gap = '4px';
+    headerTop.className = 'column-header-top';
 
     // Título da coluna com quantidade
     const columnTitle = document.createElement('h3');
     columnTitle.className = 'column-title';
     columnTitle.contentEditable = false;
-    columnTitle.style.margin = '0';
-    columnTitle.style.fontSize = '14px';
-    columnTitle.style.fontWeight = '600';
     columnTitle.textContent = `${colunaData.title} (${colunaData.clients.length})`;
     headerTop.appendChild(columnTitle);
 
     // Botões de ação
     const actionButtons = document.createElement('div');
     actionButtons.className = 'column-actions';
-    actionButtons.style.display = 'flex';
-    actionButtons.style.gap = '4px';
     actionButtons.innerHTML = `
       <button class="column-btn edit-column" title="Editar" style="background: none; border: none; cursor: pointer; padding: 4px;">✏️</button>
       <button class="column-btn color-column" title="Cor" style="background: none; border: none; cursor: pointer; padding: 4px;">🎨</button>
@@ -762,12 +753,7 @@ window.CRMKanban = (() => {
     // Linha de adesão + gordurinha
     const { totalAdesao, totalGordurinha } = calcularTotaisColuna(colunaData);
     const valoresTopo = document.createElement('div');
-    valoresTopo.className = 'valores-kanban-topo';
-    valoresTopo.style.display = 'flex';
-    valoresTopo.style.justifyContent = 'space-between';
-    valoresTopo.style.fontSize = '11px';
-    valoresTopo.style.marginTop = '4px';
-    valoresTopo.style.padding = '0 4px';
+    valoresTopo.className = 'column-values-topo';
     valoresTopo.innerHTML = `
       <span>Adesão: <strong>R$ ${totalAdesao.toFixed(2)}</strong></span>
       <span>Gordurinha: <strong>R$ ${totalGordurinha.toFixed(2)}</strong></span>
@@ -1148,7 +1134,7 @@ window.CRMKanban = (() => {
         
         // Atualiza totais
         const { totalAdesao, totalGordurinha } = calcularTotaisColuna(coluna);
-        const valoresEl = colunaEl.querySelector('.valores-topo');
+        const valoresEl = colunaEl.querySelector('.column-values-topo');
         if (valoresEl) {
           valoresEl.innerHTML = `
             <div>Adesão: <strong>R$ ${totalAdesao.toFixed(2)}</strong></div>

--- a/styles/kanban.css
+++ b/styles/kanban.css
@@ -219,11 +219,28 @@
 
 /* Header da coluna */
 .column-header {
-  padding: 1.25rem;
-  border-bottom: 1px solid #e2e8f0;
+  padding: 0.75rem 1rem;
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  gap: 4px;
+  border-bottom: 1px solid #e2e8f0;
+  margin-bottom: 1rem;
+}
+
+.column-header-top {
+  display: flex;
   justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.column-values-topo {
+  font-size: 0.75rem;
+  color: #475569;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0 2px;
 }
 
 .column-info {
@@ -231,10 +248,10 @@
 }
 
 .column-title {
-  font-size: 1.1rem;
+  font-size: 1rem;
   font-weight: 600;
   color: #1e293b;
-  margin: 0 0 0.25rem 0;
+  margin: 0;
   outline: none;
   border-radius: 4px;
   padding: 2px 4px;


### PR DESCRIPTION
## Summary
- streamline Kanban column header layout
- update DOM creation to use new classes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685edc47698c832187063d6d9604e03b