### PR TITLE
Add CSS styles for Kanban column headers

### DIFF
--- a/styles/kanban.css
+++ b/styles/kanban.css
@@ -638,3 +638,34 @@
     min-width: 240px;
   }
 }
+
+.column-header {
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.column-header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.column-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  color: #1e293b;
+}
+
+.column-values-topo {
+  font-size: 0.75rem;
+  color: #475569;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0 2px;
+}


### PR DESCRIPTION
This commit introduces new CSS rules to style the header section of Kanban columns, including the title and top values.